### PR TITLE
Fix import error in BlogPost model

### DIFF
--- a/src/posts/models.py
+++ b/src/posts/models.py
@@ -1,8 +1,5 @@
-from enum import unique
-from Scripts.pywin32_postinstall import verbose
 from django.contrib.auth import get_user_model
 from django.db import models
-from django.forms import CharField
 from django.template.defaultfilters import slugify
 from django.urls import reverse
 


### PR DESCRIPTION
## Summary
- clean up posts model imports to avoid ImportError

## Testing
- `pytest -q`
- `python src/manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_683f549aa6908322bd42f3ec3c5df9c2