### PR TITLE
Add slug generation test

### DIFF
--- a/src/posts/tests.py
+++ b/src/posts/tests.py
@@ -1,3 +1,14 @@
 from django.test import TestCase
+from django.template.defaultfilters import slugify
 
-# Create your tests here.
+from posts.models import BlogPost
+
+
+class BlogPostSlugTest(TestCase):
+    def test_slug_generated_on_save(self):
+        """Saving a BlogPost without slug should populate slug from title."""
+        title = "Un titre de test"
+        post = BlogPost(title=title)
+        post.save()
+        self.assertEqual(post.slug, slugify(title))
+


### PR DESCRIPTION
## Summary
- test that saving a BlogPost without slug generates slugified title

## Testing
- `python src/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_683f585da3988322821253cd8bb5df21